### PR TITLE
Add Biome formatter & linter

### DIFF
--- a/.biome.json
+++ b/.biome.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://biomejs.dev/schemas/biome.json",
+  "linter": { "enabled": true, "rules": { "recommended": true } },
+  "formatter": { "enabled": true }
+}

--- a/.biomeignore
+++ b/.biomeignore
@@ -1,0 +1,3 @@
+dist
+coverage
+node_modules

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "granola-ts-client",
       "devDependencies": {
         "@types/bun": "latest",
-        "biome": "^0.3.3",
+        "@biomejs/biome": "latest",
         "openapi-typescript": "^7.6.1",
         "typedoc": "^0.28.2",
       },
@@ -75,7 +75,7 @@
 
     "bcrypt-pbkdf": ["bcrypt-pbkdf@1.0.2", "", { "dependencies": { "tweetnacl": "^0.14.3" } }, "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w=="],
 
-    "biome": ["biome@0.3.3", "", { "dependencies": { "bluebird": "^3.4.1", "chalk": "^1.1.3", "commander": "^2.9.0", "editor": "^1.0.0", "fs-promise": "^0.5.0", "inquirer-promise": "0.0.3", "request-promise": "^3.0.0", "untildify": "^3.0.2", "user-home": "^2.0.0" }, "bin": { "biome": "./dist/index.js" } }, "sha512-4LXjrQYbn9iTXu9Y4SKT7ABzTV0WnLDHCVSd2fPUOKsy1gQ+E4xPFmlY1zcWexoi0j7fGHItlL6OWA2CZ/yYAQ=="],
+    "@biomejs/biome": ["@biomejs/biome@0.3.3", "", { "dependencies": { "bluebird": "^3.4.1", "chalk": "^1.1.3", "commander": "^2.9.0", "editor": "^1.0.0", "fs-promise": "^0.5.0", "inquirer-promise": "0.0.3", "request-promise": "^3.0.0", "untildify": "^3.0.2", "user-home": "^2.0.0" }, "bin": { "biome": "./dist/index.js" } }, "sha512-4LXjrQYbn9iTXu9Y4SKT7ABzTV0WnLDHCVSd2fPUOKsy1gQ+E4xPFmlY1zcWexoi0j7fGHItlL6OWA2CZ/yYAQ=="],
 
     "bluebird": ["bluebird@3.7.2", "", {}, "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="],
 

--- a/package.json
+++ b/package.json
@@ -26,15 +26,15 @@
     "build:types": "tsc -p tsconfig.build.json",
     "build:schema": "cp src/schema.d.ts dist/",
     "test": "bun test",
-    "format": "biome format . --write",
+    "format": "biome format --write .",
     "lint": "biome check .",
-    "ci": "bun run lint && bun run test && bun run build",
+    "ci": "bun run format && bun run lint && bun run test && bun run build",
     "prepublishOnly": "bun run ci"
   },
   "dependencies": {},
   "devDependencies": {
     "@types/bun": "latest",
-    "biome": "^0.3.3",
+    "@biomejs/biome": "latest",
     "openapi-typescript": "^7.6.1",
     "typescript": "^5.0.0"
   },


### PR DESCRIPTION
## Summary
- add `.biome.json` and `.biomeignore`
- update scripts in `package.json`
- depend on `@biomejs/biome`

## Testing
- `bun run format` *(fails: biome: command not found)*
- `bun run lint` *(fails: biome: command not found)*
- `bun run ci` *(fails: biome: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454e459bec8330b3115b5d791fc734