### PR TITLE
Remove unused afterAll import from tests

### DIFF
--- a/tests/http.test.ts
+++ b/tests/http.test.ts
@@ -1,12 +1,5 @@
 // tests/http.test.ts
-import {
-	afterAll,
-	beforeAll,
-	beforeEach,
-	describe,
-	expect,
-	it,
-} from "bun:test";
+import { beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { Http } from "../src/http";
 
 // Set NODE_ENV for testing


### PR DESCRIPTION
## Summary
- cleanup unused `afterAll` import in test suite

## Testing
- `bun run lint:check`
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_684577f1da148330915740944ce30bdf