### PR TITLE
Add complexity and noConsole rules

### DIFF
--- a/.biome.json
+++ b/.biome.json
@@ -7,7 +7,12 @@
 		"enabled": true,
 		"rules": {
 			"recommended": true,
-			"style/useNodejsImportProtocol": "off"
+			"style/useNodejsImportProtocol": "off",
+			"complexity/noExcessiveCognitiveComplexity": "warn",
+			"suspicious/noConsole": {
+				"level": "warn",
+				"options": { "allow": ["warn", "error", "info"] }
+			}
 		}
 	},
 	"formatter": { "enabled": true },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,9 @@
 - The configuration lives in `.biome.json` which excludes `node_modules`, `coverage`, and `*.lock` files
 - The CI process ensures clean builds by removing the `dist/` folder before linting to avoid conflicts with generated code
 - The Node import rule is disabled because the project uses Bun; add `// biome-ignore lint/style/useNodejsImportProtocol` for dynamic imports if needed.
+- Additional lint rules help keep the codebase clean:
+  - `complexity/noExcessiveCognitiveComplexity` warns when a function becomes too complex.
+  - `suspicious/noConsole` warns on `console` usage except for `warn`, `error`, and `info` calls.
 
 ### Pre-commit Checklist
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,9 @@
 - The configuration lives in `.biome.json` which excludes `node_modules`, `coverage`, and `*.lock` files
 - The CI process ensures clean builds by removing the `dist/` folder before linting to avoid conflicts with generated code
 - The Node import rule is disabled because the project uses Bun; add `// biome-ignore lint/style/useNodejsImportProtocol` for dynamic imports if needed.
+- Additional lint rules help keep the codebase clean:
+  - `complexity/noExcessiveCognitiveComplexity` warns when a function becomes too complex.
+  - `suspicious/noConsole` warns on `console` usage except for `warn`, `error`, and `info` calls.
 
 ### Pre-commit Checklist
 

--- a/examples/quick-start.ts
+++ b/examples/quick-start.ts
@@ -12,7 +12,7 @@ async function main() {
 		// Get workspaces
 		const workspaces = await client.v1_get_workspaces();
 		const workspaceCount = workspaces.workspaces?.length ?? 0;
-		console.log(`Found ${workspaceCount} workspaces`);
+		console.info(`Found ${workspaceCount} workspaces`);
 
 		// Get documents from the first workspace
 		if (workspaces.workspaces && workspaces.workspaces.length > 0) {
@@ -24,13 +24,13 @@ async function main() {
 					limit: 5,
 				});
 
-				console.log(`First 5 documents in workspace ${workspaceId}:`);
+				console.info(`First 5 documents in workspace ${workspaceId}:`);
 				if (docs.docs && docs.docs.length > 0) {
 					for (const doc of docs.docs) {
-						console.log(`- ${doc.title} (${doc.id})`);
+						console.info(`- ${doc.title} (${doc.id})`);
 					}
 				} else {
-					console.log("No documents found");
+					console.info("No documents found");
 				}
 			}
 		}

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -6,7 +6,7 @@ import { GranolaClient } from "../src";
 describe("API connectivity (manual test)", () => {
 	it("should fetch workspaces from the Granola API", async () => {
 		// Always skip this test in automated runs and CI
-		console.log("Skipping API connectivity test - requires manual token");
+		console.info("Skipping API connectivity test - requires manual token");
 
 		// Mock test pass to avoid failing the build
 		expect(true).toBe(true);


### PR DESCRIPTION
## Summary
- warn when functions get too complex
- warn on console usage except for info, warn, and error
- update docs with reasoning for new lint rules
- use `console.info` instead of `console.log` in examples and tests

## Testing
- `bun run format`
- `bun run lint`
- `bun run ci`


------
https://chatgpt.com/codex/tasks/task_e_6845867cea48833092aa015b7c6d1099