### PR TITLE
Update contribution docs for verification script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,12 +72,18 @@
 - The CI process ensures clean builds by removing the `dist/` folder before linting to avoid conflicts with generated code
 - The Node import rule is disabled because the project uses Bun; add `// biome-ignore lint/style/useNodejsImportProtocol` for dynamic imports if needed.
 
+### Documentation Consistency
+
+- README snippets and `examples/*.ts` must compile against the current generated client.
+- After running `bun run generate`, run `bun run docs:check` to compile the examples and verify key README snippets.
+
 ### Pre-commit Checklist
 
 - `bun run format` - format the code
 - `bun run lint` - fix and check lint issues
 - `bun run ci` - run tests and build
 - Write commit messages in present tense and describe the change clearly.
+- Update README snippets and examples when generated methods change and verify with `bun run docs:check`.
 
 ### File Synchronization
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,12 +72,18 @@
 - The CI process ensures clean builds by removing the `dist/` folder before linting to avoid conflicts with generated code
 - The Node import rule is disabled because the project uses Bun; add `// biome-ignore lint/style/useNodejsImportProtocol` for dynamic imports if needed.
 
+### Documentation Consistency
+
+- README snippets and `examples/*.ts` must compile against the current generated client.
+- After running `bun run generate`, run `bun run docs:check` to compile the examples and verify key README snippets.
+
 ### Pre-commit Checklist
 
 - `bun run format` - format the code
 - `bun run lint` - fix and check lint issues
 - `bun run ci` - run tests and build
 - Write commit messages in present tense and describe the change clearly.
+- Update README snippets and examples when generated methods change and verify with `bun run docs:check`.
 
 ### File Synchronization
 


### PR DESCRIPTION
## Summary
- add new `Documentation Consistency` section describing docs checks
- mention the docs verification script in the Pre-commit Checklist

## Testing
- `bun run format`
- `bun run lint`
- `bun run ci`


------
https://chatgpt.com/codex/tasks/task_e_684586d69d088330ae65c557664cc741