### PR TITLE
Cache Bun install in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,22 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    
-    - name: Setup Bun
-      uses: oven-sh/setup-bun@v1
-      with:
-        bun-version: latest
-    
-    - name: Install dependencies
-      run: bun install
+      - uses: actions/checkout@v3
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Cache Bun install
+        uses: actions/cache@v3
+        with:
+          path: $HOME/.bun/install
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
     
     - name: Run CI
       run: bun run ci


### PR DESCRIPTION
## Summary
- cache Bun runtime to speed up GitHub Actions workflow
- install dependencies with `bun install --frozen-lockfile`

## Testing
- `bun run format`
- `bun run lint`
- `bun run ci`


------
https://chatgpt.com/codex/tasks/task_e_68458c4f9e748330ad79bb111751252f