### PR TITLE
Clarify generated directory handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,9 @@ let workspace: WorkspaceResponse;
 ```
 ## Generate Types
 
-Run `bun run generate` to refresh client and schema types from `openapi.yaml`. The command writes
-the API client and models to `src/generated/`, which are committed to the
-repository. CI runs this step automatically before building.
+Run `bun run generate` to refresh client and schema types from `openapi.yaml`.
+The command writes the API client and models to `src/generated/`, which is
+ignored by git. CI runs this step automatically before building.
 
 
 ## Development


### PR DESCRIPTION
## Summary
- explain that `src/generated` is ignored by git

## Testing
- `bun run format`
- `bun run lint`
- `bun run ci`


------
https://chatgpt.com/codex/tasks/task_e_68458de53bc4833085cced6f6272e97f