### PR TITLE
Remove test coverage quota

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@
 - Biome automatically fixes most linting and formatting issues when using `bun run lint`
 - The CI process uses a clean build approach: removes dist/, lints source code, runs tests, then builds
 - Follow the established TypeScript configuration without modifications
-- Maintain 80%+ test coverage for all new code
+- Do not enforce any specific test coverage percentage
 - Use async/await syntax rather than Promises with then/catch
 
 ### Linting and Formatting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@
 - Biome automatically fixes most linting and formatting issues when using `bun run lint`
 - The CI process uses a clean build approach: removes dist/, lints source code, runs tests, then builds
 - Follow the established TypeScript configuration without modifications
-- Maintain 80%+ test coverage for all new code
+- Do not enforce any specific test coverage percentage
 - Use async/await syntax rather than Promises with then/catch
 
 ### Linting and Formatting


### PR DESCRIPTION
## Summary
- stop mandating a minimum test coverage in the dev guides

## Testing
- `bun run format`
- `bun run lint`
- `bun run ci`


------
https://chatgpt.com/codex/tasks/task_e_68458f23ae74833081754bd0ff51d628