### PR TITLE
Update quick-start import

### DIFF
--- a/examples/quick-start.ts
+++ b/examples/quick-start.ts
@@ -1,4 +1,4 @@
-import GranolaClient from "../src/index";
+import GranolaClient from "granola-ts-client";
 
 // Example usage of the client
 async function main() {


### PR DESCRIPTION
## Summary
- use the published package in the quick-start example

## Testing
- `bun run format`
- `bun run lint`
- `bun run ci`
- `GRANOLA_ACCESS_TOKEN=dummy bun examples/quick-start.ts` *(fails: `client.v1_get_workspaces is not a function`)*

------
https://chatgpt.com/codex/tasks/task_e_68458de6dc3083308990323a73cf9c3a