### PR TITLE
Fix CI workflow indentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,12 @@ jobs:
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
-    
-    - name: Run CI
-      run: bun run ci
-    
-    - name: Upload artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: dist
-        path: dist/
+
+      - name: Run CI
+        run: bun run ci
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/


### PR DESCRIPTION
## Summary
- fix inconsistent indentation in workflow steps
- remove trailing spaces

## Testing
- `bun run format`
- `bun run lint`
- `bun run ci`
- `yamllint -d '{extends: default, rules: {document-start: disable, brackets: disable, truthy: disable}}' .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_6845914fd43483308cdc3498cb8b3d6d